### PR TITLE
fix: `dataSource.destroy` runs as synchronously

### DIFF
--- a/src/sharding-manager.ts
+++ b/src/sharding-manager.ts
@@ -73,10 +73,6 @@ export class ShardingManager {
 
     async destroy() {
         this._destroyed = true;
-        await Promise.all(
-            this.dataSources.map((dataSource) => {
-                dataSource.destroy();
-            })
-        );
+        await Promise.all(this.dataSources.map((dataSource) => dataSource.destroy()));
     }
 }

--- a/src/test/repository-service.spec.ts
+++ b/src/test/repository-service.spec.ts
@@ -31,7 +31,10 @@ describe('Repository Service', () => {
     });
 
     afterEach(async () => {
-        dataSource?.destroy();
+        if (dataSource) {
+            await dataSource.destroy();
+            dataSource.dataSources.forEach((dataSource) => expect(dataSource.isInitialized).toEqual(false));
+        }
     });
 
     it('Case1 - insert into last shard', async () => {

--- a/src/test/sharding-manager.spec.ts
+++ b/src/test/sharding-manager.spec.ts
@@ -29,7 +29,10 @@ describe('ShardingManager', () => {
     });
 
     afterEach(async () => {
-        dataSource?.destroy();
+        if (dataSource) {
+            await dataSource.destroy();
+            dataSource.dataSources.forEach((dataSource) => expect(dataSource.isInitialized).toEqual(false));
+        }
     });
 
     it('DataSource', async () => {


### PR DESCRIPTION
`dataSource.destroy` should be runs as synchronously.

---
dataSource.destroy가 Async로 동작하도록 합니다. 